### PR TITLE
fix(readme): 安装命令改为 swcc@swcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 ```bash
 # 安装
 claude plugins marketplace add ylxmf2005/swcc
-claude plugins install swcc
+claude plugins install swcc@swcc
 
 # 在任意项目中
 /zhili 给这个项目加 JWT 认证


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to specify a pinned plugin version for more consistent setup experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->